### PR TITLE
Cast progressLabel value with precision to the nearest integer

### DIFF
--- a/GTProgressBar/Classes/GTProgressBar.swift
+++ b/GTProgressBar/Classes/GTProgressBar.swift
@@ -294,7 +294,7 @@ public class GTProgressBar: UIView {
     }
     
     private func updateProgressLabelText() {
-        progressLabel.text = "\(Int(_progress * 100))%"
+        progressLabel.text = "\(Int(round(_progress * 100)))%"
     }
     
     public func animateTo(progress: CGFloat, completion: (() -> Void)? = nil) {


### PR DESCRIPTION
The progressLabel was cast only with int() but it is necessary to explicitly round the the result of the calculation to the nearest integer, to get a correct result in the label.