### PR TITLE
Add swift_version to Podspec

### DIFF
--- a/GTProgressBar.podspec
+++ b/GTProgressBar.podspec
@@ -24,5 +24,5 @@ GTProgressBar is a customisable progress bar written in Swift 4. It supports bot
   s.tvos.deployment_target  = '10.0'
 
   s.source_files = 'GTProgressBar/Classes/**/*'
-  
+  s.swift_version = '4.0'  
 end


### PR DESCRIPTION
This forces CocoaPods to set the SWIFT_VERSION flag to 4.0 to allow compiling in Swift 4.2 projects.